### PR TITLE
Adding Fedora 35 as a supported distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ bit firmware on an amd64 Atom CPU.
 By default the RCA Cambio runs in portrait mode, but before booting you'll want
 to add `video=efifb fbcon=rotate:1` to your kernel command line.
 
+To get out of portrait mode by default in Fedora,
+1. Get card devices by executing `ls /sys/class/drm`
+2. Find the one for your display, you can run `cat /sys/class/drm/<card device name here>/modes` to see the resolution and determine which is which (mine was `card0-DSI-1`)
+3. Use Grubby to add the following kernel arguments (using my example above, note that `left_side_up` is also an option): `sudo grubby --update-kernel=ALL --args="video=DSI-1:panel_orientation=right_side_up"`
+
 Linux Kernel 4.11 and higher is needed for DRM video acceleration.
 
 # Similar pages

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ bit firmware on an amd64 Atom CPU.
 - Void Linux
 - [OpenBSD](openbsd/), not a Linux distro but includes support for bootia32.efi on the
   install media (install61.fs).
+- [Fedora 35](https://download.fedoraproject.org/pub/fedora/linux/releases/35/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-35-1.2.iso)
 
 # Hardware
 


### PR DESCRIPTION
I was able to install Fedora 35 out-of-the-box using the x86_64 ISO